### PR TITLE
ABCL atomic interface

### DIFF
--- a/tests/atomic-test.lisp
+++ b/tests/atomic-test.lisp
@@ -39,3 +39,56 @@
     (is (= 8 (atomic-get value)))
     (is (= 9 (atomic-swap value fn2)))
     (is (= 9 (atomic-get value)))))
+
+#+abcl
+(test abcl-atomic-swap-integer
+  "ABCL atomic swap integer (as well as atomic-cas) test in threads."
+  (let* ((n 100)
+         (aint (make-atomic-integer :value 0))
+         (threads (loop repeat n
+                        collect (bt:make-thread (lambda ()
+                                                  (atomic-swap aint (lambda (int) (+ int 1000)))
+                                                  (atomic-swap aint (lambda (int) (- int 10000)))
+                                                  (atomic-swap aint (lambda (int) (+ int 10000)))
+                                                  (atomic-swap aint (lambda (int) (- int 1000))))))))
+    (mapc #'bt:join-thread threads)
+    (is (= 0 (atomic-get aint)))))
+
+#+abcl
+(test abcl-atomic-swap-reference
+  "ABCL atomic swap reference (as well as atomic-cas) test in threads."
+  (let* ((n 100)
+         (a-ref (make-atomic-reference :value nil))
+         (threads (loop repeat n
+                        collect (bt:make-thread (lambda ()
+                                                  (atomic-swap a-ref (lambda (ref) (push 0 ref)))
+                                                  (atomic-swap a-ref (lambda (ref) (pop ref) nil))
+                                                  (atomic-swap a-ref (lambda (ref) (push 1 ref)))
+                                                  (atomic-swap a-ref (lambda (ref) (pop ref) nil)))))))
+    (mapc #'bt:join-thread threads)
+    (is (eql nil (atomic-get a-ref)))))
+
+#+abcl
+(test atomic-incf
+  "Basic tests of increasing an atomic-integer object."
+  (let ((aint (make-atomic-integer :value 0)))
+    (is (= 0 (atomic::atomic-incf aint)))
+    (is (= 1 (atomic-get aint)))
+    (is (= 1 (atomic::atomic-incf aint 10)))
+    (is (= 11 (atomic-get aint)))
+    (is (= 11 (atomic::atomic-incf aint -10)))
+    (is (= 1 (atomic-get aint)))))
+
+#+abcl
+(test atomic-incf-threads
+  "Test increasing an atomic-integer object in threads."
+  (let* ((n 100)
+         (aint (make-atomic-integer :value 0))
+         (threads (loop repeat n
+                        collect (bt:make-thread (lambda ()
+                                                  (atomic::atomic-incf aint 100)
+                                                  (atomic::atomic-incf aint -1000)
+                                                  (atomic::atomic-incf aint +1000)
+                                                  (atomic::atomic-incf aint -100))))))
+    (mapc #'bt:join-thread threads)
+    (is (= 0 (atomic-get aint)))))


### PR DESCRIPTION
Issue #60.
This PR has `atomic-swap` for both `atomic-integer` and `atomic-reference`.
`atomic-incf` has been impled too, as `+atomic-long-incf+` has already been there, but `atomic-incf` is not experted.
All tests were passed ^_^.