### PR TITLE
Add a way to pass additional arguments to an actor constructor

### DIFF
--- a/src/actor-api.lisp
+++ b/src/actor-api.lisp
@@ -85,8 +85,7 @@ If you have additional initializations to make you can do so in `initialize-inst
 
 - `init` and `destroy`: are functions that take one argument, the actor instance.
 Those hooks are called on (after) initialization and (after) stop respectively.
-
-- `other-init-args`: are additional arguments passed to `initialize-instance` of the actor class."))
+"))
 
 (defgeneric pre-start (actor)
   (:documentation

--- a/src/actor-api.lisp
+++ b/src/actor-api.lisp
@@ -2,7 +2,6 @@
   (:use :cl)
   (:nicknames :act)
   (:export #:make-actor
-           #:other-init-args
            #:actor
            #:tell
            #:!
@@ -28,11 +27,7 @@
 (in-package :sento.actor)
 
 (defclass actor (actor-cell)
-  ((other-init-args :initarg :other-init-args
-                    :initform nil
-                    :reader other-init-args
-                    :documentation "Other init args passed to `make-actor`")
-   (receive :initarg :receive
+  ((receive :initarg :receive
             :initform (error "'receive' must be specified!")
             :reader receive
             :documentation
@@ -71,7 +66,7 @@ There is asynchronous `tell`, a synchronous `ask-s` and asynchronous `ask` which
 
 To stop an actors message processing in order to cleanup resouces you should `tell` (or `ask-s`) the `:stop` message. It will respond with `:stopped` (in case of `ask(-s)`)."))
 
-(defgeneric make-actor (receive &key name state type init destroy other-init-args)
+(defgeneric make-actor (receive &key name state type init destroy &allow-other-keys)
   (:documentation
    "Constructs an `actor`.
 

--- a/src/actor-context-api.lisp
+++ b/src/actor-context-api.lisp
@@ -18,7 +18,7 @@
 (in-package :sento.actor-context)
 
 (defgeneric actor-of (context
-                      &key receive init destroy dispatcher state type name queue-size
+                      &key receive init destroy dispatcher state type name
                       &allow-other-keys)
   (:documentation "Interface for creating an actor.
 
@@ -38,7 +38,12 @@ This function allows to unsubsribe from event-stream or such.
 - `:dispatcher` key can be used to define the message dispatcher manually.
   Options that are available by default are `:shared` (default) and `:pinned`. When you defined a custom dispatcher it can be specified here.
 - `:type` can specify a custom actor class. See `act:make-actor` for more info.
-- `:name` to set a specific name to the actor, otherwise a random name will be used."))
+- `:name` to set a specific name to the actor, otherwise a random name will be used.
+
+Additional options:
+
+- `:queue-size` limits the message-box's size. By default, it is unbounded.
+"))
 
 (defgeneric find-actors (context path &key test key)
   (:documentation "Returns actors to be found by the criteria of:

--- a/src/actor-context-api.lisp
+++ b/src/actor-context-api.lisp
@@ -18,7 +18,8 @@
 (in-package :sento.actor-context)
 
 (defgeneric actor-of (context
-                      &key receive init destroy dispatcher state type name other-args)
+                      &key receive init destroy dispatcher state type name queue-size
+                      &allow-other-keys)
   (:documentation "Interface for creating an actor.
 
 **!!! Attention:** this factory function wraps the `act:make-actor` functionality to something more simple to use. 
@@ -37,8 +38,7 @@ This function allows to unsubsribe from event-stream or such.
 - `:dispatcher` key can be used to define the message dispatcher manually.
   Options that are available by default are `:shared` (default) and `:pinned`. When you defined a custom dispatcher it can be specified here.
 - `:type` can specify a custom actor class. See `act:make-actor` for more info.
-- `:name` to set a specific name to the actor, otherwise a random name will be used.
-- `:other-args` are in the actor instance as `other-init-args` and can be acted upon in i.e. `pre-start` for additional initialization."))
+- `:name` to set a specific name to the actor, otherwise a random name will be used."))
 
 (defgeneric find-actors (context path &key test key)
   (:documentation "Returns actors to be found by the criteria of:

--- a/src/actor-context.lisp
+++ b/src/actor-context.lisp
@@ -135,6 +135,7 @@ An `act:actor` contains an `actor-context`."
              :dispatcher dispatcher
              :queue-size queue-size))
 
+
 ;; test 2-arity function with 'path' and 'act-cell-name' (default)
 (defmethod find-actors ((context actor-context) path &key (test #'string=) (key #'act-cell:name))
   "See `ac:find-actors`"

--- a/src/actor-context.lisp
+++ b/src/actor-context.lisp
@@ -107,7 +107,7 @@ An `act:actor` contains an `actor-context`."
     context))
 
 (defmethod actor-of ((context actor-context)
-                     &rest all-args
+                     &rest rest
                      &key
                      receive
                      (init nil)
@@ -118,15 +118,24 @@ An `act:actor` contains an `actor-context`."
                      (name nil)
                      (queue-size nil)
                      &allow-other-keys)
-  (declare (ignore init destroy state type name))
   "See `ac:actor-of`."
   (check-type receive function "a function!")
-  (alexandria:remove-from-plistf all-args
+  (alexandria:remove-from-plistf rest
                                  :queue-size
-                                 :dispatcher)
+                                 :dispatcher
+                                 :init
+                                 :destroy
+                                 :state
+                                 :type
+                                 :name)
   (%actor-of context
              (lambda () (apply #'act:make-actor receive
-                               all-args))
+                               :init init
+                               :destroy destroy
+                               :state state
+                               :type type
+                               :name name
+                               rest))
              :dispatcher dispatcher
              :queue-size queue-size))
 

--- a/src/actor-context.lisp
+++ b/src/actor-context.lisp
@@ -120,14 +120,10 @@ An `act:actor` contains an `actor-context`."
                      &allow-other-keys)
   "See `ac:actor-of`."
   (check-type receive function "a function!")
+
   (alexandria:remove-from-plistf rest
                                  :queue-size
-                                 :dispatcher
-                                 :init
-                                 :destroy
-                                 :state
-                                 :type
-                                 :name)
+                                 :dispatcher)
   (%actor-of context
              (lambda () (apply #'act:make-actor receive
                                :init init

--- a/src/actor-context.lisp
+++ b/src/actor-context.lisp
@@ -107,22 +107,28 @@ An `act:actor` contains an `actor-context`."
     context))
 
 (defmethod actor-of ((context actor-context)
-                     &key receive
-                       (init nil) (destroy nil)
-                       (dispatcher :shared) (state nil)
-                       (type 'act:actor) (name nil)
-                       (other-args nil))
+                     &rest all-args
+                     &key
+                     receive
+                     (init nil)
+                     (destroy nil)
+                     (dispatcher :shared)
+                     (state nil)
+                     (type 'act:actor)
+                     (name nil)
+                     (queue-size nil)
+                     &allow-other-keys)
+  (declare (ignore init destroy state type name))
   "See `ac:actor-of`."
   (check-type receive function "a function!")
+  (alexandria:remove-from-plistf all-args
+                                 :queue-size
+                                 :dispatcher)
   (%actor-of context
-             (lambda () (act:make-actor receive
-                                   :state state
-                                   :name name
-                                   :type type
-                                   :init init
-                                   :destroy destroy
-                                   :other-init-args other-args))
-             :dispatcher dispatcher))
+             (lambda () (apply #'act:make-actor receive
+                               all-args))
+             :dispatcher dispatcher
+             :queue-size queue-size))
 
 ;; test 2-arity function with 'path' and 'act-cell-name' (default)
 (defmethod find-actors ((context actor-context) path &key (test #'string=) (key #'act-cell:name))

--- a/src/actor-system.lisp
+++ b/src/actor-system.lisp
@@ -217,7 +217,6 @@ Users should use `ac:find-actors`."
                           (state nil)
                           (type 'act:actor)
                           (name nil)
-                          (queue-size nil)
                      &allow-other-keys)
   "See `ac:actor-of`"
   (apply #'%actor-of
@@ -230,7 +229,6 @@ Users should use `ac:find-actors`."
          :state state
          :type type
          :name name
-         :queue-size queue-size
          rest))
 
 (defmethod find-actors ((self actor-system) path &key (test #'string=) (key #'act-cell:name))

--- a/src/actor-system.lisp
+++ b/src/actor-system.lisp
@@ -150,15 +150,7 @@ See `config:config-from`."
   "Private API to create system actors. Context-key is either `:internal` or `:user`
 Users should use `actor-of`."
   (alexandria:remove-from-plistf rest
-                                 :context-key
-                                 :receive
-                                 :init
-                                 :destroy 
-                                 :dispatcher 
-                                 :state 
-                                 :type 
-                                 :name 
-                                 :queue-size)
+                                 :context-key)
   (apply #'ac:actor-of
          (actor-context-for-key context-key system)
          :receive receive
@@ -228,15 +220,6 @@ Users should use `ac:find-actors`."
                           (queue-size nil)
                      &allow-other-keys)
   "See `ac:actor-of`"
-  (alexandria:remove-from-plistf rest
-                                 :receive
-                                 :init
-                                 :destroy
-                                 :dispatcher
-                                 :state
-                                 :type 
-                                 :name
-                                 :queue-size)
   (apply #'%actor-of
          system
          :context-key :user

--- a/src/actor-system.lisp
+++ b/src/actor-system.lisp
@@ -136,26 +136,24 @@ See `config:config-from`."
     (otherwise (user-actor-context system))))
 
 (defun %actor-of (system
+                  &rest all-args
                   &key receive
-                    init
-                    destroy
-                    dispatcher
-                    state
-                    (type 'act:actor)
-                    name
-                    (context-key :user)
-                    (other-args nil))
+                       init
+                       destroy
+                       dispatcher
+                       state
+                       (type 'act:actor)
+                       name
+                       (context-key :user)
+                       (queue-size nil)
+                  &allow-other-keys)
+  (declare (ignore receive init destroy dispatcher state type name queue-size))
   "Private API to create system actors. Context-key is either `:internal` or `:user`
 Users should use `actor-of`."
-  (ac:actor-of (actor-context-for-key context-key system)
-    :receive receive
-    :init init
-    :destroy destroy
-    :dispatcher dispatcher
-    :state state
-    :type type
-    :name name
-    :other-args other-args))
+  (alexandria:remove-from-plistf all-args
+                                 :context-key)
+  (apply #'ac:actor-of (actor-context-for-key context-key system)
+         all-args))
 
 (defun %find-actors (system path &key test key context-key)
   "Private API to find actors in both contexts the actor-system supports.
@@ -203,22 +201,22 @@ Users should use `ac:find-actors`."
 ;; ----------------------------------------
 
 (defmethod actor-of ((system actor-system)
+                     &rest all-args
                      &key receive
-                       (init nil) (destroy nil)
-                       (dispatcher :shared) (state nil)
-                       (type 'act:actor) (name nil)
-                       (other-args nil))
+                          (init nil)
+                          (destroy nil)
+                          (dispatcher :shared)
+                          (state nil)
+                          (type 'act:actor)
+                          (name nil)
+                          (queue-size nil)
+                     &allow-other-keys)
+  (declare (ignore receive init destroy dispatcher state type name queue-size))
   "See `ac:actor-of`"
-  (%actor-of system
-    :receive receive
-    :init init
-    :destroy destroy
-    :dispatcher dispatcher
-    :state state
-    :type type
-    :name name
-    :context-key :user
-    :other-args other-args))
+  (apply #'%actor-of
+         system
+         :context-key :user
+         all-args))
 
 (defmethod find-actors ((self actor-system) path &key (test #'string=) (key #'act-cell:name))
   "See `ac:find-actors`"

--- a/src/actor-system.lisp
+++ b/src/actor-system.lisp
@@ -136,7 +136,7 @@ See `config:config-from`."
     (otherwise (user-actor-context system))))
 
 (defun %actor-of (system
-                  &rest all-args
+                  &rest rest
                   &key receive
                        init
                        destroy
@@ -147,13 +147,29 @@ See `config:config-from`."
                        (context-key :user)
                        (queue-size nil)
                   &allow-other-keys)
-  (declare (ignore receive init destroy dispatcher state type name queue-size))
   "Private API to create system actors. Context-key is either `:internal` or `:user`
 Users should use `actor-of`."
-  (alexandria:remove-from-plistf all-args
-                                 :context-key)
-  (apply #'ac:actor-of (actor-context-for-key context-key system)
-         all-args))
+  (alexandria:remove-from-plistf rest
+                                 :context-key
+                                 :receive
+                                 :init
+                                 :destroy 
+                                 :dispatcher 
+                                 :state 
+                                 :type 
+                                 :name 
+                                 :queue-size)
+  (apply #'ac:actor-of
+         (actor-context-for-key context-key system)
+         :receive receive
+         :init init
+         :destroy destroy
+         :dispatcher dispatcher
+         :state state
+         :type type
+         :name name
+         :queue-size queue-size
+         rest))
 
 (defun %find-actors (system path &key test key context-key)
   "Private API to find actors in both contexts the actor-system supports.
@@ -201,7 +217,7 @@ Users should use `ac:find-actors`."
 ;; ----------------------------------------
 
 (defmethod actor-of ((system actor-system)
-                     &rest all-args
+                     &rest rest
                      &key receive
                           (init nil)
                           (destroy nil)
@@ -211,12 +227,28 @@ Users should use `ac:find-actors`."
                           (name nil)
                           (queue-size nil)
                      &allow-other-keys)
-  (declare (ignore receive init destroy dispatcher state type name queue-size))
   "See `ac:actor-of`"
+  (alexandria:remove-from-plistf rest
+                                 :receive
+                                 :init
+                                 :destroy
+                                 :dispatcher
+                                 :state
+                                 :type 
+                                 :name
+                                 :queue-size)
   (apply #'%actor-of
          system
          :context-key :user
-         all-args))
+         :init init
+         :receive receive
+         :destroy destroy
+         :dispatcher dispatcher
+         :state state
+         :type type
+         :name name
+         :queue-size queue-size
+         rest))
 
 (defmethod find-actors ((self actor-system) path &key (test #'string=) (key #'act-cell:name))
   "See `ac:find-actors`"

--- a/src/actor.lisp
+++ b/src/actor.lisp
@@ -22,7 +22,7 @@
 (define-symbol-macro *state* act-cell:*state*)
 (define-symbol-macro *sender* act-cell:*sender*)
 
-(defmethod make-actor (receive &rest all-args
+(defmethod make-actor (receive &rest rest
                                &key
                                name
                                state
@@ -30,12 +30,15 @@
                                (init nil)
                                (destroy nil)
                                &allow-other-keys)
-  (declare (ignore name state init destroy))
-  (alexandria:remove-from-plistf all-args
+  (alexandria:remove-from-plistf rest
                                  :type)
   (apply #'make-instance type
          :receive receive
-         all-args))
+         :init init
+         :destroy destroy
+         :name name
+         :state state
+         rest))
 
 
 (defun finalize-initialization (actor message-box actor-context)

--- a/src/actor.lisp
+++ b/src/actor.lisp
@@ -30,10 +30,11 @@
                                (init nil)
                                (destroy nil)
                                &allow-other-keys)
-  (declare (ignore name state receive init destroy))
+  (declare (ignore name state init destroy))
   (alexandria:remove-from-plistf all-args
                                  :type)
   (apply #'make-instance type
+         :receive receive
          all-args))
 
 
@@ -256,18 +257,16 @@ Use this from within receive function to reply to a sender."
   (ac:all-actors (context actor)))
 
 (defmethod actor-of ((actor actor)
+                     &rest all-args
                      &key receive
-                       (init nil) (destroy nil)
-                       (dispatcher :shared) (state nil)
-                       (type 'act:actor) (name nil)
-                       (other-args nil))
+                          (init nil)
+                          (destroy nil)
+                          (dispatcher :shared)
+                          (state nil)
+                          (type 'act:actor)
+                          (name nil))
+  (declare (ignore init destroy dispatcher state type name))
   "`ac:actor-context` protocol implementation"
-  (ac:actor-of (context actor)
-    :receive receive
-    :init init
-    :destroy destroy
-    :dispatcher dispatcher
-    :state state
-    :type type
-    :name name
-    :other-args other-args))
+  (apply #'ac:actor-of
+         (context actor)
+         all-args))

--- a/src/actor.lisp
+++ b/src/actor.lisp
@@ -260,7 +260,7 @@ Use this from within receive function to reply to a sender."
   (ac:all-actors (context actor)))
 
 (defmethod actor-of ((actor actor)
-                     &rest all-args
+                     &rest rest
                      &key receive
                           (init nil)
                           (destroy nil)
@@ -268,8 +268,8 @@ Use this from within receive function to reply to a sender."
                           (state nil)
                           (type 'act:actor)
                           (name nil))
-  (declare (ignore init destroy dispatcher state type name))
+  (declare (ignore receive init destroy dispatcher state type name))
   "`ac:actor-context` protocol implementation"
   (apply #'ac:actor-of
          (context actor)
-         all-args))
+         rest))

--- a/src/actor.lisp
+++ b/src/actor.lisp
@@ -22,19 +22,20 @@
 (define-symbol-macro *state* act-cell:*state*)
 (define-symbol-macro *sender* act-cell:*sender*)
 
-(defmethod make-actor (receive &key
-                                 name state
-                                 (type 'actor)
-                                 (init nil)
-                                 (destroy nil)
-                                 (other-init-args nil))
-  (make-instance type
-                 :name name
-                 :state state
-                 :receive receive
-                 :init init
-                 :destroy destroy
-                 :other-init-args other-init-args))
+(defmethod make-actor (receive &rest all-args
+                               &key
+                               name
+                               state
+                               (type 'actor)
+                               (init nil)
+                               (destroy nil)
+                               &allow-other-keys)
+  (declare (ignore name state receive init destroy))
+  (alexandria:remove-from-plistf all-args
+                                 :type)
+  (apply #'make-instance type
+         all-args))
+
 
 (defun finalize-initialization (actor message-box actor-context)
   "Private API: finalize initialization of the actor with a `mesgb:message-box` and an `ac:actor-context`."

--- a/src/fcomputation.lisp
+++ b/src/fcomputation.lisp
@@ -98,7 +98,6 @@ Create a future with:
   "Is `future` completed? Returns either `t` or `nil`."
   (with-slots (promise) future
     (or (promise-finished-p promise)
-        ;; QUESTION:
         ;; When queue is full and we are trying to ask
         ;; actor do more job, it will return a future
         ;; where promise is not finished but errored.

--- a/src/fcomputation.lisp
+++ b/src/fcomputation.lisp
@@ -7,6 +7,7 @@
            #:make-future
            #:futurep
            #:complete-p
+           #:error-p
            #:fcompleted
            #:fawait
            #:fresult
@@ -96,7 +97,21 @@ Create a future with:
 (defun complete-p (future)
   "Is `future` completed? Returns either `t` or `nil`."
   (with-slots (promise) future
-    (promise-finished-p promise)))
+    (or (promise-finished-p promise)
+        ;; QUESTION:
+        ;; When queue is full and we are trying to ask
+        ;; actor do more job, it will return a future
+        ;; where promise is not finished but errored.
+        ;; I think this state should be considered as
+        ;; COMPLETED, because nothing will happen with
+        ;; such future anymore.
+        (blackbird-base::promise-errored-p promise))))
+
+(defun error-p (future)
+  "Is `future` errored? Returns either `t` or `nil`."
+  (with-slots (promise) future
+    ;; For some reason, this function is not external in the blackbird :(
+    (blackbird-base::promise-errored-p promise)))
 
 (defun %fcompleted (future completed-fun)
   (with-slots (promise) future

--- a/tests/actor-test.lisp
+++ b/tests/actor-test.lisp
@@ -50,11 +50,10 @@
 
 (test make-actor--custom-type
   "Tests making an actor instance that is not the default 'actor type."
-  (let ((actor (make-actor "foo"
-                           :receive (lambda (msg)
-                                      (declare (ignore msg)))
+  (let ((actor (make-actor (lambda (msg)
+                             (declare (ignore msg)))
                            :type 'custom-actor
-                           :custom-arg 100 )))
+                           :custom-arg 100)))
     (is (typep actor
                'custom-actor))
     (is (equal 100

--- a/tests/actor-test.lisp
+++ b/tests/actor-test.lisp
@@ -42,10 +42,24 @@
     (is (string= "Foo" (act-cell:name cut)))
     (is (equalp '(1) (act-cell:state cut)))))
 
-(defclass custom-actor (actor) ())
+
+(defclass custom-actor (actor)
+  ((custom-arg :initarg :custom-arg
+               :initform nil
+               :reader custom-arg)))
+
 (test make-actor--custom-type
   "Tests making an actor instance that is not the default 'actor type."
-  (is (typep (make-actor "foo" :type 'custom-actor) 'custom-actor)))
+  (let ((actor (make-actor "foo"
+                           :receive (lambda (msg)
+                                      (declare (ignore msg)))
+                           :type 'custom-actor
+                           :custom-arg 100 )))
+    (is (typep actor
+               'custom-actor))
+    (is (equal 100
+               (custom-arg actor)))))
+
 
 (test make-actor--with-init-and-destroy
   "Tests the `init' and `destroy' hooks."
@@ -494,4 +508,3 @@
                "Counter of unsuccessful attempts should be equal to 9, but it is ~A"
                queue-full-counter))
       (ac:shutdown sys))))
-

--- a/tests/fcomputation-test.lisp
+++ b/tests/fcomputation-test.lisp
@@ -52,6 +52,16 @@
     (fcompleted future (value) (setf completed-value value))
     (is (eq t (assert-cond (lambda () (string= "fulfilled" completed-value)) 1)))))
 
+(test complete-with-error
+  "Test the completion with fcompleted callback with an error."
+
+  (let ((future (make-future (lambda (resolve-fun)
+                               (declare (ignore resolve-fun))
+                               (error "Some error")))))
+    (is (eq :not-ready (fresult future)))
+    (is (complete-p future))
+    (is (error-p future))))
+
 (test mapping-futures--with-fut-macro
   "Tests mapping futures"
   (flet ((future-generator (x)


### PR DESCRIPTION
I've removed :other-args argument.
Probably it should be returned back for backward compatibility?
