### PR TITLE
Fix error handling in handle-message function.

### DIFF
--- a/src/actor-cell.lisp
+++ b/src/actor-cell.lisp
@@ -171,7 +171,7 @@ If a `sender' is specified the result will be sent to the sender."
 In case of `withreply-p`, the `response` is filled because submitting to the message-box is synchronous.
 Otherwise submitting is asynchronous and `response` is just `t`.
 In case the actor-cell was stopped it will respond with just `:stopped`.
-In case no messge-box is configured this function respnds with `:no-message-handling`."
+In case no message-box is configured this function responds with `:no-message-handling`."
   (log:debug "~a: submitting message: ~a, withreply-p: ~a, sender: ~a, timeout: ~a"
              (name actor-cell) message withreply-p sender time-out)
 
@@ -216,7 +216,7 @@ In case no messge-box is configured this function respnds with `:no-message-hand
                  (setf state *state*)
                  handle-result)))
             (t internal-handle-result)))
-      (t (c)
+      (serious-condition (c)
         (log:error "~a: error condition was raised: ~%~a~%"
                    (name actor-cell)
                    c)

--- a/tests/actor-test.lisp
+++ b/tests/actor-test.lisp
@@ -539,3 +539,15 @@
            (is (= 1 (length (filter (lambda (x) (if x x)) tells))))
            (is (= 9 (length (filter #'null tells)))))
       (ac:shutdown sys))))
+
+
+(test dont-break-on-non-error-signals
+  "Test contructor and attach a msgbox manually."
+  (let ((cut (make-actor (lambda (msg)
+                           (declare (ignore msg))
+                           (warn "Received a message!")
+                           (values :result)))))
+    (setf (act-cell:msgbox cut)
+          (make-instance 'mesgb:message-box/bt))
+    (is (eql :result (ask-s cut "hello")))
+    (ask-s cut :stop)))


### PR DESCRIPTION
Previously handler-case form captured all signals including non errors. For example if you did `(warn "foo")` inside the actor's code, then message processing was interrupted because warn function signals a non-error condition. You can test this behaviour on this minimal example:

```lisp
CL-USER> (handler-case
             (progn
               (warn "foo")
               :non-handled)
           (t ()
             :handled))
:HANDLED
CL-USER> (handler-case
             (progn
               (warn "foo")
               :non-handled)
           (serious-condition ()
             :handled))
WARNING: foo
:NON-HANDLED
```