### PR TITLE
Benchmark was refactored to not overflow memory

### DIFF
--- a/sento.asd
+++ b/sento.asd
@@ -111,6 +111,19 @@
                "mgl-pax/full")
   :components ((:file "documentation")))
 
+
+;; --------------------------------
+;; benchmark
+;; --------------------------------
+
+(defsystem "sento/bench"
+  :author "Manfred Bergmann"
+  :description "Benchmark for Sento"
+  :depends-on ("sento"
+               "trivial-benchmark"
+               "trivial-garbage")
+  :components ((:file "bench")))
+
 ;; load system
 ;; (asdf:load-system "sento")
 ;;

--- a/src/actor-context.lisp
+++ b/src/actor-context.lisp
@@ -45,7 +45,8 @@ The `actor-system` and the `actor` itself are composed of an `actor-context`."))
 
 (defun %message-box-for-dispatcher-id (context dispatcher-id queue-size)
   (case dispatcher-id
-    (:pinned (make-instance 'mesgb:message-box/bt))
+    (:pinned (make-instance 'mesgb:message-box/bt
+                            :max-queue-size queue-size))
     (otherwise (let ((dispatcher (%get-shared-dispatcher (system context) dispatcher-id)))
                  (unless dispatcher
                    (error (format nil "No such dispatcher identifier '~a' exists!" dispatcher-id)))

--- a/src/queue/queue-locked.lisp
+++ b/src/queue/queue-locked.lisp
@@ -40,6 +40,12 @@ than the 'queue' implementation of lparallel.
   (not (or (queue-head queue)
            (queue-tail queue))))
 
+(defun size (queue)
+  (let ((head (queue-head queue))
+        (tail (queue-tail queue)))
+    (+ (length head)
+       (length tail))))
+
 
 #|
 queue implementation from lparallel.
@@ -104,3 +110,9 @@ Copyright (c) 2011-2012, James M. Lawrence. All rights reserved.
 (defmethod emptyq-p ((self queue-unbounded))
   (with-slots (queue) self
     (emptyp queue)))
+
+
+(defmethod queued-count ((self queue-unbounded))
+  (with-slots (queue lock) self
+    (bt2:with-lock-held (lock)
+      (size queue))))


### PR DESCRIPTION
Now threads generating load are pause generation if actor's queue size growth above given threshold.

Now benchmark uses trivial-benchmark library which formats results in a unified way on different lisp implementations. However the most wide variety of metrics are supported for SBCL only.

The pro of using trivial-benchmark here is that it automates repeated tests. Now you can set a number of runs for the benchmark and a duration of the each run. And trivial-benchmark will automatically calculate average, median and deviation of each metric across all runs.

For Sento benchmark I've added a special metric - a message per second. During my tests satisfactory results were obtained when test duration was set to 10 seconds and a number of runs to 60.

On my Macbook M1 with 16G of memory benchmark results are:

```
SENTO/BENCH> (lisp-implementation-type)
"SBCL"
SENTO/BENCH> (lisp-implementation-version)
"2.5.0.116-bd18806aa"
SENTO/BENCH> (uiop:get-optimization-settings)
((SPEED 1) (SPACE 1) (SAFETY 1) (DEBUG 1) (COMPILATION-SPEED 1))


Results for benchmark: (:DISPATCHER :PINNED :WITH-REPLY-P NIL :ASYNC-ASK-P NIL
                        :NUM-SHARED-WORKERS 8 :QUEUE-SIZE NIL
                        :WAIT-IF-QUEUE-LARGE-THAN 10000)
┌─────────────────────┬───────────────┬─────────────┬─────────────┬─────────────┬─────────────┬─────────────┐
│ -                   │ TOTAL         │ MINIMUM     │ MAXIMUM     │ MEDIAN      │ AVERAGE     │ DEVIATION   │
├─────────────────────┼───────────────┼─────────────┼─────────────┼─────────────┼─────────────┼─────────────┤
│ MESSAGES-PER-SECOND │    59763090.0 │    657702.9 │   1103853.4 │   1014389.2 │   996051.44 │    76637.07 │
├─────────────────────┼───────────────┼─────────────┼─────────────┼─────────────┼─────────────┼─────────────┤
│ USER-RUN-TIME       │      707.3372 │    7.839694 │   12.719797 │   11.985142 │   11.788954 │    0.839375 │
├─────────────────────┼───────────────┼─────────────┼─────────────┼─────────────┼─────────────┼─────────────┤
│ SYSTEM-RUN-TIME     │     232.37593 │    2.988574 │    4.180502 │    3.896854 │    3.872932 │    0.177386 │
├─────────────────────┼───────────────┼─────────────┼─────────────┼─────────────┼─────────────┼─────────────┤
│ REAL-TIME           │      635.9478 │      10.508 │      10.637 │      10.608 │   10.599131 │    0.029722 │
├─────────────────────┼───────────────┼─────────────┼─────────────┼─────────────┼─────────────┼─────────────┤
│ GC-RUN-TIME         │         3.924 │        0.05 │       0.075 │       0.067 │      0.0654 │    0.005194 │
├─────────────────────┼───────────────┼─────────────┼─────────────┼─────────────┼─────────────┼─────────────┤
│ GC-REAL-TIME        │         4.052 │        0.05 │       0.128 │       0.067 │    0.067533 │    0.009718 │
├─────────────────────┼───────────────┼─────────────┼─────────────┼─────────────┼─────────────┼─────────────┤
│ PROCESSOR-CYCLES    │           0.0 │         0.0 │         0.0 │         0.0 │         0.0 │         0.0 │
├─────────────────────┼───────────────┼─────────────┼─────────────┼─────────────┼─────────────┼─────────────┤
│ EVAL-CALLS          │       26520.0 │       442.0 │       442.0 │       442.0 │       442.0 │         0.0 │
├─────────────────────┼───────────────┼─────────────┼─────────────┼─────────────┼─────────────┼─────────────┤
│ LAMBDAS-CONVERTED   │           0.0 │         0.0 │         0.0 │         0.0 │         0.0 │         0.0 │
├─────────────────────┼───────────────┼─────────────┼─────────────┼─────────────┼─────────────┼─────────────┤
│ PAGE-FAULTS         │           0.0 │         0.0 │         0.0 │         0.0 │         0.0 │         0.0 │
├─────────────────────┼───────────────┼─────────────┼─────────────┼─────────────┼─────────────┼─────────────┤
│ BYTES-CONSED        │ 121484440000. │ 1338653400. │ 2245857000. │ 2063355600. │ 2024740700. │ 155061730.0 │
└─────────────────────┴───────────────┴─────────────┴─────────────┴─────────────┴─────────────┴─────────────┘
```

Note, you will need the latest trivial-benchmark with [this PR](https://github.com/Shinmera/trivial-benchmark/pull/14) merged. It is available from https://ultralisp.org