### PR TITLE
Now message-box/bt class will restart thread if it was aborted because of a non-local exit from processing loop.

### DIFF
--- a/sento.asd
+++ b/sento.asd
@@ -69,6 +69,7 @@
                "lparallel"
                "cl-mock")
   :components ((:module "tests"
+                :serial t
                 :components
                 ((:file "all-test")
                  (:file "miscutils-test")
@@ -97,8 +98,7 @@
                  (:file "actor-tree-test")
                  (:file "spawn-in-receive-test")
                  (:file "test-utils")
-                 (:file "message-box-test"
-                     :depends-on ("test-utils")))))
+                 (:file "message-box-test"))))
   :description "Test system for sento"
   :perform (test-op (op c) (symbol-call :fiveam :run!
                                         (uiop:find-symbol* '#:test-suite

--- a/sento.asd
+++ b/sento.asd
@@ -65,6 +65,7 @@
   :author "Manfred Bergmann"
   :depends-on ("sento"
                "fiveam"
+               "serapeum"
                "lparallel"
                "cl-mock")
   :components ((:module "tests"
@@ -95,7 +96,9 @@
                  (:file "actor-system-test")
                  (:file "actor-tree-test")
                  (:file "spawn-in-receive-test")
-                 )))
+                 (:file "test-utils")
+                 (:file "message-box-test"
+                     :depends-on ("test-utils")))))
   :description "Test system for sento"
   :perform (test-op (op c) (symbol-call :fiveam :run!
                                         (uiop:find-symbol* '#:test-suite

--- a/tests/message-box-test.lisp
+++ b/tests/message-box-test.lisp
@@ -1,0 +1,111 @@
+(defpackage :sento.message-box-test
+  (:use :cl :fiveam :cl-mock :sento.actor :sento.future)
+  (:shadow #:! #:?)
+  (:import-from #:miscutils
+                #:assert-cond
+                #:await-cond
+                #:filter)
+  (:import-from #:timeutils
+                #:ask-timeout)
+  (:import-from #:sento.messageb
+                #:message-box/bt
+                #:submit
+                #:no-result
+                #:queue-thread
+                #:stop)
+  (:import-from #:sento.test-utils
+                #:parametrized-test)
+  (:import-from #:ac
+                #:actor-of))
+
+(in-package :sento.message-box-test)
+
+(def-suite message-box-tests
+  :description "message-box tests"
+  :in sento.tests:test-suite)
+
+(in-suite message-box-tests)
+
+
+(defun wait-while-thread-will-die (msgbox &key (timeout 10))
+  (let ((wait-until (+ (get-internal-real-time) (* timeout
+                                                   internal-time-units-per-second))))
+    (with-slots (queue-thread)
+        msgbox
+      (loop :while (bt2:thread-alive-p queue-thread)
+            :do (sleep 0.1)
+                (when (< wait-until
+                         (get-internal-real-time))
+                  (error "Thread didn't die in ~A seconds."
+                         timeout))))))
+
+
+(parametrized-test bt-box-resurrects-thread-after-abort-if-handler-catches-all-signals
+    ((withreply-p timeout)
+     (nil         nil)
+     (t           1)
+     (t           nil))
+  
+  "Simulates a situation when error has happened during message processing, and ABORT restart was invoked.
+   Usually this kill a thread, but here we ensure that by the thread is resurrected when we submit a
+   subsequent message."
+
+  (flet ((kill-by-restart-invoke (msg)
+           (declare (ignore msg))
+           (handler-case
+               ;; This way we are simulating that the user choose
+               ;; an ABORT restart in the IDE during debug session:
+               (handler-bind ((serious-condition #'abort))
+                 (error "Die, thread, die!"))
+             ;; This part the same as error handling code in the
+             ;; SENTO.ACTOR-CELL:HANDLE-MESSAGE function:
+             ;; 
+             ;; TODO: t was used to check if it is able to
+             ;; catch stack unwinding because of INVOKE-RESTART,
+             ;; but it can't.
+             (t (c)
+               (log:error "error condition was raised: ~%~a~%"
+                          c)
+               (cons :handler-error c)))))
+    
+    (let ((box (make-instance 'message-box/bt
+                              :name "foo")))
+      (unwind-protect
+           (progn
+             (let ((first-reply
+                     (submit box "The Message"
+                             t
+                             ;; Don't wait for result here, because we are
+                             ;; intentionally raise error here and will never
+                             ;; return a result:
+                             nil
+                             (list #'kill-by-restart-invoke))))
+               (is (equal first-reply
+                          'no-result)))
+
+             (wait-while-thread-will-die box)
+
+             (is (not
+                  (bt2:thread-alive-p
+                   (slot-value box 'queue-thread))))
+
+             (let ((result (handler-case
+                               (submit box "The Message"
+                                       withreply-p
+                                       timeout
+                                       (list (lambda (msg)
+                                               (reverse msg))))
+                             (ask-timeout ()
+                               :timeout))))
+
+               (cond
+                 (withreply-p
+                  (is (string= "egasseM ehT" result)))
+                 (t
+                  (is (eql result t)))))
+
+             (is (bt2:thread-alive-p
+                  (slot-value box 'queue-thread))))
+                         
+        ;; Cleanup a thread:
+        (stop box t)))))

--- a/tests/test-utils.lisp
+++ b/tests/test-utils.lisp
@@ -1,0 +1,48 @@
+(defpackage #:sento.test-utils
+  (:use #:cl)
+  (:import-from #:serapeum
+                #:eval-always)
+  (:import-from #:alexandria
+                #:parse-body)
+  (:export #:parametrized-test))
+(in-package #:sento.test-utils)
+
+
+
+(eval-always
+  (defun generate-test-form (base-test-name parameter-names parameters docstring body-form)
+    (let* ((test-name-str (format nil
+                                  "~A-[~{~A=~S~^ ~}]"
+                                  base-test-name
+                                  (loop :for name :in parameter-names
+                                        :for value :in parameters
+                                        :appending (list name value))))
+           (test-name (intern test-name-str))
+           (bindings (loop :for name :in parameter-names
+                           :for value :in parameters
+                           :collect (list name value))))
+      `(5am:test ,test-name
+         ,docstring
+         (let ,bindings
+           ,@body-form)))))
+
+
+(defmacro parametrized-test (name ((&rest parameter-names) &rest parameter-tuples) &body body)
+  (multiple-value-bind (forms decls docstring)
+      (parse-body body :documentation t :whole name)
+    (let* ((docstring (or docstring ""))
+           (body-forms (append decls forms)))
+  
+      (let ((tests (loop :for parameters :in parameter-tuples
+                         :collect (generate-test-form name parameter-names parameters docstring body-forms))))
+        `(progn
+           ;; If somebody has changed parameters, we need to remove obsolte tests from the 5AM test registry.
+           (loop :with prefix-to-search := ,(format nil "~A-" name)
+                 :for candidate-name in (5am:test-names)
+                 :for candidate-name-str := (symbol-name candidate-name)
+                 :when (and (serapeum:length<= prefix-to-search candidate-name-str)
+                            (string= (subseq candidate-name-str 0 (length prefix-to-search))
+                                     prefix-to-search))
+                   :do (5am:rem-test candidate-name))
+           ,@tests)))))
+

--- a/tests/test-utils.lisp
+++ b/tests/test-utils.lisp
@@ -28,6 +28,35 @@
 
 
 (defmacro parametrized-test (name ((&rest parameter-names) &rest parameter-tuples) &body body)
+  "Generates a separate tests for each parameter combination.
+
+   - NAME is the prefix for all tests in the group. The rest of each test name consists of parameters and values.
+   - PARAMETER-NAMES should be a list of symbolic names of variables to be bound during BODY execution.
+   - PARAMETER-TUPLES should be a list of lists of values to be bound to variables given in PARAMETER-NAMES.
+
+   Example:
+
+   (parametrized-test bt-box-test
+       ((withreply-p timeout)
+        (nil         nil)
+        (t           1)
+        (t           nil))
+
+     (do-something with-reply-p timeout))
+
+   This form will be expanded to the code which will remove all 5AM tests starting with BT-BOX-TEST-
+   and then will create 3 tests like this one:
+
+
+   (test |BT-BOX-TEST-[WITHREPLY-P=T TIMEOUT=1]|
+      (let ((withreply-p t) (timeout 1))
+        (do-something with-reply-p timeout)))
+
+   As you can see, this test binds WITHREPLY-P and TIMEOUT variables to a values given in the second row of PARAMETER-TUPLES.
+
+   Name of each test will include parameter variables for this test. This way it will be easy to tell which parameter combination
+   fails.
+"
   (multiple-value-bind (forms decls docstring)
       (parse-body body :documentation t :whole name)
     (let* ((docstring (or docstring ""))


### PR DESCRIPTION
I've measured performance before these changes and after them and didn't notice significant changes. Results of the benchmark along with the baseline results are available in this gist:

https://gist.github.com/svetlyak40wt/a1097ab7d501087ca366d5addb410ebe

Note, this PR is the replacement for https://github.com/mdbergmann/cl-gserver/pull/101

It uses another approach for checking if thread is died – catches non-local exit using `unwind-protect`.
Also, in this thread I've removed a special brach for processing the `time-out` while waiting for response. Now both cases (with `time-out` and without) are handled using the same code, relying on `timeout` argument of condition wait function.

Peformance testing didn't show any difference with the code from the master branch.