### PR TITLE
Add configurable max-message-length to tcp-transport (default 2MB)

### DIFF
--- a/specs/remoting-state.md
+++ b/specs/remoting-state.md
@@ -39,9 +39,11 @@
 - **43 tests, 120 checks, all passing**
 - Note: `make-remote-ref` takes explicit `transport` and `serializer` arguments (simplified in Phase 5 via remoting context). `local-sender-path` slot defaults to `"/__local__"`, overridden by Phase 5 to `sento://host:port/__responses__`. Correlation IDs use a thread-safe counter + timestamp (no external UUID library needed). `handle-response`, `pending-asks`, `pending-asks-lock`, and `parse-remote-uri` are public API used by Phase 5 for response routing.
 
-## TODO (post-phase)
-
-- **Max message size:** Currently `tcp-transport` framing has no size limit (4-byte header allows ~4GB). Add a configurable `:max-message-length` to the remoting config (passed through to `tcp-transport`). Check in `%read-frame` (reject before allocating) and `%write-frame` (reject before sending). Sensible default: 16MB.
+### Max Message Size (done)
+- `src/remoting/transport.lisp` — added `max-message-length` slot to `transport` base class (default 2MB), `message-too-large-error` condition with `size` and `max` slots
+- `src/remoting/transport-tcp.lisp` — `%read-frame` rejects before allocating, `%write-frame` rejects before sending
+- `tests/remoting/transport-test.lisp` — 4 tests (default 2MB, custom config, send rejects oversized, receive rejects oversized)
+- **59 tests, 160 checks, all passing**
 
 ### Phase 5: Remoting Integration (End-to-End) (done)
 - `src/remoting/remoting.lisp` — `sento.remoting` package implementation: `remoting-context` class, `enable-remoting`/`disable-remoting`/`remoting-enabled-p`/`remoting-port` lifecycle API, `make-remote-ref` convenience factory, inbound message routing (`%handle-inbound-tell`, `%handle-inbound-ask`), correlation-id based response routing (`%route-response`). Imports symbols via `eval-when shadowing-import` from `bt2`, `renv`, `rseri`, `rtrans`, `rtrans-tcp`, `rref`, `act`, `ac`, `str` for unqualified use.

--- a/src/remoting/transport-tcp.lisp
+++ b/src/remoting/transport-tcp.lisp
@@ -8,11 +8,13 @@
                 #:transport-tls-config
                 #:transport-tls-provider
                 #:transport-running-p
+                #:transport-max-message-length
                 #:transport-message-handler
                 #:transport-start
                 #:transport-stop
                 #:transport-send
                 #:transport-error
+                #:message-too-large-error
                 #:connection-refused-error
                 #:connection-timeout-error
                 #:send-failed-error)
@@ -87,9 +89,14 @@
 ;; framing: 4-byte big-endian length prefix
 ;; ---------------------------------
 
-(defun %write-frame (stream payload)
-  "Write a length-prefixed frame: 4-byte big-endian length + payload bytes."
+(defun %write-frame (stream payload max-length)
+  "Write a length-prefixed frame: 4-byte big-endian length + payload bytes.
+Signals message-too-large-error if payload exceeds MAX-LENGTH."
   (let ((len (length payload)))
+    (when (> len max-length)
+      (error 'message-too-large-error
+             :size len :max max-length
+             :message (format nil "Outbound message ~a bytes exceeds max ~a" len max-length)))
     (write-byte (ldb (byte 8 24) len) stream)
     (write-byte (ldb (byte 8 16) len) stream)
     (write-byte (ldb (byte 8  8) len) stream)
@@ -97,8 +104,9 @@
     (write-sequence payload stream)
     (force-output stream)))
 
-(defun %read-frame (stream)
-  "Read a length-prefixed frame. Returns payload byte vector, or NIL on EOF."
+(defun %read-frame (stream max-length)
+  "Read a length-prefixed frame. Returns payload byte vector, or NIL on EOF.
+Signals message-too-large-error if the declared length exceeds MAX-LENGTH."
   (let ((b3 (read-byte stream nil nil)))
     (unless b3 (return-from %read-frame nil))
     (let ((b2 (read-byte stream nil nil))
@@ -106,15 +114,19 @@
           (b0 (read-byte stream nil nil)))
       (unless (and b2 b1 b0)
         (return-from %read-frame nil))
-      (let* ((len (logior (ash b3 24) (ash b2 16) (ash b1 8) b0))
-             (buf (make-array len :element-type '(unsigned-byte 8))))
-        (let ((pos 0))
-          (loop :while (< pos len)
-                :do (let ((n (read-sequence buf stream :start pos :end len)))
-                      (when (= n pos)
-                        (return-from %read-frame nil))
-                      (setf pos n))))
-        buf))))
+      (let ((len (logior (ash b3 24) (ash b2 16) (ash b1 8) b0)))
+        (when (> len max-length)
+          (error 'message-too-large-error
+                 :size len :max max-length
+                 :message (format nil "Inbound message ~a bytes exceeds max ~a" len max-length)))
+        (let ((buf (make-array len :element-type '(unsigned-byte 8))))
+          (let ((pos 0))
+            (loop :while (< pos len)
+                  :do (let ((n (read-sequence buf stream :start pos :end len)))
+                        (when (= n pos)
+                          (return-from %read-frame nil))
+                        (setf pos n))))
+          buf)))))
 
 ;; ---------------------------------
 ;; envelope serialization (to/from bytes)
@@ -268,7 +280,7 @@
            (lambda ()
              (unwind-protect
                   (handler-case
-                      (loop :for frame = (%read-frame stream)
+                      (loop :for frame = (%read-frame stream (transport-max-message-length transport))
                             :while (and frame (transport-running-p transport))
                             :do (handler-case
                                     (let ((envelope (%deserialize-envelope frame)))
@@ -389,7 +401,7 @@
                     (error c)))))
     (handler-case
         (let ((frame (%serialize-envelope envelope)))
-          (%write-frame stream frame))
+          (%write-frame stream frame (transport-max-message-length transport)))
       (error (c)
         ;; Remove broken connection so next attempt reconnects
         (%remove-connection transport target-host target-port)

--- a/src/remoting/transport.lisp
+++ b/src/remoting/transport.lisp
@@ -15,8 +15,12 @@
            #:transport-start
            #:transport-stop
            #:transport-send
+           #:transport-max-message-length
            ;; conditions
            #:transport-error
+           #:message-too-large-error
+           #:message-too-large-size
+           #:message-too-large-max
            #:connection-refused-error
            #:connection-refused-host
            #:connection-refused-port
@@ -36,6 +40,18 @@
 (define-condition transport-error (remoting-error)
   ()
   (:documentation "Base condition for transport-related errors."))
+
+(define-condition message-too-large-error (transport-error)
+  ((size :initarg :size
+         :reader message-too-large-size
+         :documentation "The actual message size in bytes.")
+   (max :initarg :max
+        :reader message-too-large-max
+        :documentation "The maximum allowed size in bytes."))
+  (:report (lambda (c stream)
+             (format stream "Message too large: ~a bytes (max ~a)"
+                     (message-too-large-size c) (message-too-large-max c))))
+  (:documentation "Signaled when a message exceeds the configured maximum size."))
 
 (define-condition connection-refused-error (transport-error)
   ((host :initarg :host
@@ -102,6 +118,10 @@
                     :accessor transport-message-handler
                     :initform nil
                     :documentation "Function called with (envelope) for inbound messages.")
+   (max-message-length :initarg :max-message-length
+                       :reader transport-max-message-length
+                       :initform (* 2 1024 1024)
+                       :documentation "Maximum message size in bytes. Default 2MB.")
    (running-p :initform nil
               :accessor transport-running-p
               :documentation "Whether this transport is currently running."))

--- a/tests/remoting/transport-test.lisp
+++ b/tests/remoting/transport-test.lisp
@@ -5,7 +5,9 @@
                 #:transport-stop
                 #:transport-send
                 #:transport-running-p
+                #:transport-max-message-length
                 #:connection-refused-error
+                #:message-too-large-error
                 #:send-failed-error)
   (:import-from :sento.remoting.transport-tcp
                 #:tcp-transport
@@ -303,3 +305,72 @@ Binds: server-transport, server-port, client-transport."
       (let ((received (first received-envelopes)))
         (is (string= "/user/foo" (envelope-target-path received)))
         (is (eq :tell (envelope-message-type received)))))))
+
+;; ---------------------------------
+;; max message size tests
+;; ---------------------------------
+
+(test transport--default-max-message-length
+  "Tests that the default max-message-length is 2MB."
+  (let ((transport (make-instance 'tcp-transport :host "127.0.0.1" :port 0)))
+    (is (= (* 2 1024 1024) (transport-max-message-length transport)))))
+
+(test transport--custom-max-message-length
+  "Tests that max-message-length can be configured."
+  (let ((transport (make-instance 'tcp-transport
+                                  :host "127.0.0.1" :port 0
+                                  :max-message-length (* 8 1024 1024))))
+    (is (= (* 8 1024 1024) (transport-max-message-length transport)))))
+
+(test transport--send-rejects-oversized-message
+  "Tests that sending a message larger than max-message-length signals message-too-large-error."
+  (let* ((received-envelopes nil)
+         (received-lock (make-lock :name "received-lock"))
+         (server (make-instance 'tcp-transport :host "127.0.0.1" :port 0))
+         (client (make-instance 'tcp-transport
+                                :host "127.0.0.1" :port 0
+                                :max-message-length 1024)))
+    (transport-start server
+                     (lambda (env)
+                       (with-lock-held (received-lock)
+                         (push env received-envelopes))))
+    (let ((port (tcp-transport-actual-port server)))
+      (transport-start client (lambda (env) (declare (ignore env))))
+      (unwind-protect
+           (let ((big-envelope (%make-test-envelope
+                                :message-text (make-string 2000 :initial-element #\x))))
+             (signals message-too-large-error
+               (transport-send client "127.0.0.1" port big-envelope)))
+        (transport-stop client)
+        (transport-stop server)))))
+
+(test transport--receive-rejects-oversized-message
+  "Tests that receiving a message larger than max-message-length drops the connection."
+  (let* ((received-envelopes nil)
+         (received-lock (make-lock :name "received-lock"))
+         ;; Server has a small limit
+         (server (make-instance 'tcp-transport
+                                :host "127.0.0.1" :port 0
+                                :max-message-length 1024))
+         ;; Client has a large limit so it can send
+         (client (make-instance 'tcp-transport
+                                :host "127.0.0.1" :port 0
+                                :max-message-length (* 1024 1024))))
+    (transport-start server
+                     (lambda (env)
+                       (with-lock-held (received-lock)
+                         (push env received-envelopes))))
+    (let ((port (tcp-transport-actual-port server)))
+      (transport-start client (lambda (env) (declare (ignore env))))
+      (unwind-protect
+           (progn
+             ;; Send a message that exceeds the server's limit
+             (let ((big-envelope (%make-test-envelope
+                                  :message-text (make-string 2000 :initial-element #\x))))
+               (finishes (transport-send client "127.0.0.1" port big-envelope)))
+             ;; Server should NOT have received it
+             (sleep 0.5)
+             (with-lock-held (received-lock)
+               (is (= 0 (length received-envelopes)))))
+        (transport-stop client)
+        (transport-stop server)))))


### PR DESCRIPTION
Prevents unbounded memory allocation from malicious or corrupted frames. Checked in %read-frame before allocating and %write-frame before sending.